### PR TITLE
Fixing "Uninstall Misconfigured Service" error for ubuntu 18.04,

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,7 +137,7 @@ class gitlab_ci_multi_runner (
         command  => "service ${service} stop; ${service} uninstall",
         user     => root,
         provider => shell,
-        unless   => "grep '${toml_file}' ${service_file}",
+        unless   => "[ -f ${service_file} ] && grep '${toml_file}' ${service_file}",
     } ->
     exec { 'Ensure Service':
         command  => "${service} install --user ${user} --config ${toml_file} --working-directory ${home_path}",


### PR DESCRIPTION
The error ocurrs when the service_file doesn't exist and the puppet module fails trying run the "Uninstall Misconfigured Service" step,
which isn't needed since it on 18.04 the issue it's trying to fix doesn't exist